### PR TITLE
Varibow Pal Fix R4.0.0+

### DIFF
--- a/R/palettes.R
+++ b/R/palettes.R
@@ -123,5 +123,5 @@ build_palette <- function(central_color,
 varibow <- function(n_colors) {
   sats <- rep_len(c(0.55,0.7,0.85,1),length.out = n_colors)
   vals <- rep_len(c(1,0.8,0.6),length.out = n_colors)
-  sub("FF$","",grDevices::rainbow(n_colors, s = sats, v = vals))
+  grDevices::rainbow(n_colors, s = sats, v = vals, alpha = NULL)
 }


### PR DESCRIPTION
Hi,

Just adding a quick fix here due to breaking change in R4.0.0+ that results in `varibow` function returning invalid palette.  grDevices functions in R4.0.0+ don't add any alpha values to the end of hex codes if alpha is not explicitly defined.  Therefore the `sub` call in current function ends up removing the real ends of some hex codes resulting in invalid 4 character codes.  

PR specifies `alpha = NULL` so that the `sub` call isn't needed when using R less that 4.0.0 and avoids issue when using greater than 4.0.0.

Best,
Sam